### PR TITLE
ブログに関する機能更新など

### DIFF
--- a/src/components/NewsCard.tsx
+++ b/src/components/NewsCard.tsx
@@ -24,10 +24,10 @@ const NewsCard: FC<NewsCardProps> = ({
   return (
     <a
       href={url}
-      className="block w-full max-w-md overflow-hidden bg-white rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200"
+      className="w-full max-w-md h-[360px] overflow-hidden bg-white rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 flex flex-col"
     >
       {/* Image Section */}
-      <div className="relative h-48 w-full overflow-hidden">
+      <div className="relative h-48 w-full overflow-hidden flex-shrink-0">
         <img
           src={image}
           alt="Card layout"
@@ -36,13 +36,21 @@ const NewsCard: FC<NewsCardProps> = ({
       </div>
 
       {/* Content Section with specific padding */}
-      <div className="p-4">
-        {/* Title with 16px padding */}
-        <h2 className="text-xl font-bold mb-4 px-4">{title}</h2>
-        {/* Description with 16px padding on sides */}
-        <p className="text-gray-600 mb-4 px-4">{description}</p>
+      <div className="p-4 flex flex-col flex-grow">
+        {/* Title with 16px padding - 1行に制限 */}
+        <h2 className="text-xl font-bold mb-4 px-4 overflow-hidden" style={{
+          display: '-webkit-box',
+          WebkitLineClamp: 1,
+          WebkitBoxOrient: 'vertical'
+        }}>{title}</h2>
+        {/* Description with 16px padding on sides - 2行に制限 */}
+        <p className="text-gray-600 mb-4 px-4 overflow-hidden" style={{
+          display: '-webkit-box',
+          WebkitLineClamp: 2,
+          WebkitBoxOrient: 'vertical'
+        }}>{description}</p>
         {/* Footer Section with 16px bottom padding */}
-        <div className="flex justify-between items-center px-4 pb-4">
+        <div className="flex justify-between items-center px-4 pb-4 mt-auto">
           {/* User Info */}
           <div className="flex items-center gap-2">
             <div className="h-8 w-8 rounded-full overflow-hidden bg-gray-200">

--- a/src/components/NewsCard.tsx
+++ b/src/components/NewsCard.tsx
@@ -24,7 +24,7 @@ const NewsCard: FC<NewsCardProps> = ({
   return (
     <a
       href={url}
-      className="w-full max-w-md h-[360px] overflow-hidden bg-white rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 flex flex-col"
+      className="w-full max-w-sm h-[360px] overflow-hidden bg-white rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 flex flex-col mx-auto"
     >
       {/* Image Section */}
       <div className="relative h-48 w-full overflow-hidden flex-shrink-0">

--- a/src/components/NewsCard.tsx
+++ b/src/components/NewsCard.tsx
@@ -24,7 +24,7 @@ const NewsCard: FC<NewsCardProps> = ({
   return (
     <a
       href={url}
-      className="w-full max-w-sm h-[360px] overflow-hidden bg-white rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 flex flex-col mx-auto"
+      className="w-full max-w-sm custom-md:w-[390px] custom-md:max-w-[390px] h-[360px] overflow-hidden bg-white rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 flex flex-col mx-auto"
     >
       {/* Image Section */}
       <div className="relative h-48 w-full overflow-hidden flex-shrink-0">
@@ -38,17 +38,27 @@ const NewsCard: FC<NewsCardProps> = ({
       {/* Content Section with specific padding */}
       <div className="p-4 flex flex-col flex-grow">
         {/* Title with 16px padding - 1行に制限 */}
-        <h2 className="text-xl font-bold mb-4 px-4 overflow-hidden" style={{
-          display: '-webkit-box',
-          WebkitLineClamp: 1,
-          WebkitBoxOrient: 'vertical'
-        }}>{title}</h2>
+        <h2
+          className="text-xl font-bold mb-4 px-4 overflow-hidden"
+          style={{
+            display: "-webkit-box",
+            WebkitLineClamp: 1,
+            WebkitBoxOrient: "vertical",
+          }}
+        >
+          {title}
+        </h2>
         {/* Description with 16px padding on sides - 2行に制限 */}
-        <p className="text-gray-600 mb-4 px-4 overflow-hidden" style={{
-          display: '-webkit-box',
-          WebkitLineClamp: 2,
-          WebkitBoxOrient: 'vertical'
-        }}>{description}</p>
+        <p
+          className="text-gray-600 mb-4 px-4 overflow-hidden"
+          style={{
+            display: "-webkit-box",
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: "vertical",
+          }}
+        >
+          {description}
+        </p>
         {/* Footer Section with 16px bottom padding */}
         <div className="flex justify-between items-center px-4 pb-4 mt-auto">
           {/* User Info */}
@@ -77,10 +87,10 @@ const NewsCard: FC<NewsCardProps> = ({
 export default NewsCard;
 
 {
-  /* 
+  /*
 
   使い方
-  
+
 <NewsCard
 image="https://example.com/sample.jpg"
 title="新しいプロジェクトが始まりました"
@@ -91,7 +101,7 @@ authorImage="/author-image.jpg"
 date="2024.10.01"
 url="https://example.com/project" // URLプロパティを追加
 client:load
-/> 
+/>
 
   */
 }

--- a/src/components/menu.tsx
+++ b/src/components/menu.tsx
@@ -33,17 +33,19 @@ const Menu: React.FC = () => {
   // ポップアップを開く
   const openPopup = (e: React.MouseEvent) => {
     // 「入会申し込み」リンクの場合、デフォルトの挙動を防止
-    if ((e.target as HTMLElement).closest('a')?.textContent === "入会申し込み") {
+    if (
+      (e.target as HTMLElement).closest("a")?.textContent === "入会申し込み"
+    ) {
       e.preventDefault();
       setIsPopupOpen(true);
-      document.body.style.overflow = 'hidden'; // スクロールを無効化
+      document.body.style.overflow = "hidden"; // スクロールを無効化
     }
   };
 
   // ポップアップを閉じる
   const closePopup = () => {
     setIsPopupOpen(false);
-    document.body.style.overflow = ''; // スクロールを再有効化
+    document.body.style.overflow = ""; // スクロールを再有効化
   };
 
   // メニュー以外をクリックしたときに、メニューを閉じる
@@ -76,14 +78,14 @@ const Menu: React.FC = () => {
 
     // ESCキーでポップアップを閉じる
     const handleEscKey = (event: KeyboardEvent) => {
-      if (isPopupOpen && event.key === 'Escape') {
+      if (isPopupOpen && event.key === "Escape") {
         closePopup();
       }
     };
 
     document.addEventListener("mousedown", handlePopupClickOutside);
     document.addEventListener("keydown", handleEscKey);
-    
+
     return () => {
       document.removeEventListener("mousedown", handlePopupClickOutside);
       document.removeEventListener("keydown", handleEscKey);
@@ -138,16 +140,23 @@ const Menu: React.FC = () => {
                   : "opacity-0 -translate-y-4 pointer-events-none"
               }`}
             >
-              <nav className="flex flex-col items-end gap-6 p-4" onClick={openPopup}>
+              <nav
+                className="flex flex-col items-end gap-6 p-4"
+                onClick={openPopup}
+              >
                 {links.map((link, index) => (
                   <a
                     key={index}
                     href={link.href}
-                    onClick={link.label === "入会申し込み" ? (e) => {
-                      e.preventDefault();
-                      setIsOpen(false);
-                      setIsPopupOpen(true);
-                    } : () => setIsOpen(false)}
+                    onClick={
+                      link.label === "入会申し込み"
+                        ? (e) => {
+                            e.preventDefault();
+                            setIsOpen(false);
+                            setIsPopupOpen(true);
+                          }
+                        : () => setIsOpen(false)
+                    }
                     className={`flex items-center justify-center text-sm font-medium transition-all duration-200 ${
                       link.label === "入会申し込み"
                         ? "relative overflow-hidden text-white font-bold py-2 px-4 rounded-lg bg-[#F5BF48] transition-all duration-300 before:absolute before:inset-0 before:bg-[linear-gradient(94deg,#F5BF48_0.43%,#F7BC5B_33.92%,#EFA169_100%)] before:opacity-0 hover:before:opacity-100 before:transition-all before:duration-300 z-10"
@@ -164,7 +173,7 @@ const Menu: React.FC = () => {
       </div>
 
       {/* デスクトップ用メニュー（md以上）：従来の配置 */}
-      <div className="hidden md:block p-0 w-40 md:absolute top-[5rem] right-[0rem] pb-[5rem]">
+      <div className="hidden md:block p-0 w-40 md:absolute top-[5rem] right-[0rem] pb-[0rem]">
         <div className="flex flex-col items-center w-full">
           <div className="flex justify-center items-center gap-2 mb-10">
             <a href="/" className="flex items-center gap-2">
@@ -207,50 +216,67 @@ const Menu: React.FC = () => {
       {/* ポップアップ */}
       {isPopupOpen && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 transition-opacity duration-300">
-          <div 
+          <div
             ref={popupContentRef}
             className="bg-white rounded-xl shadow-2xl max-w-md w-full mx-4 overflow-hidden animate-popup"
             style={{
-              animation: 'popup 0.4s ease-out forwards'
+              animation: "popup 0.4s ease-out forwards",
             }}
           >
             {/* ポップアップヘッダー */}
             <div className="bg-gradient-to-r from-blue-600 to-indigo-700 p-6 text-white">
               <div className="flex justify-between items-center">
                 <h3 className="text-xl font-bold">Discordに参加しよう！</h3>
-                <button onClick={closePopup} className="text-white hover:text-gray-200">
-                  <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                <button
+                  onClick={closePopup}
+                  className="text-white hover:text-gray-200"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="h-6 w-6"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M6 18L18 6M6 6l12 12"
+                    />
                   </svg>
                 </button>
               </div>
             </div>
-            
+
             {/* ポップアップコンテンツ */}
             <div className="p-6">
               <div className="mb-6">
-                <img 
-                  src="/sns-discord.svg" 
-                  alt="Discord Icon" 
-                  className="w-16 h-16 mx-auto text-indigo-600" 
+                <img
+                  src="/sns-discord.svg"
+                  alt="Discord Icon"
+                  className="w-16 h-16 mx-auto text-indigo-600"
                 />
               </div>
-              
+
               <div className="space-y-4 text-gray-700">
                 <p>
-                  <strong>4,5月はDiscordを中心に新歓イベントを開催します！</strong>
+                  <strong>
+                    4,5月はDiscordを中心に新歓イベントを開催します！
+                  </strong>
                 </p>
                 <p>
-                  このDiscordサーバーに参加すると、プログラミングサークルTNDの<strong>仮加入メンバー</strong>となります。
+                  このDiscordサーバーに参加すると、プログラミングサークルTNDの
+                  <strong>仮加入メンバー</strong>となります。
                 </p>
                 <p>
                   新入生同士でたくさん交流して、プログラミングの楽しさを一緒に体験しましょう！
                 </p>
               </div>
-              
+
               <div className="mt-8">
-                <a 
-                  href="https://discord.gg/k3qMBEn3CC" 
+                <a
+                  href="https://discord.gg/k3qMBEn3CC"
                   target="_blank"
                   className="block w-full bg-indigo-600 hover:bg-indigo-700 text-white text-center font-semibold py-3 px-4 rounded-lg transition-colors"
                 >

--- a/src/content/blog/2025-03-new-website-launch.md
+++ b/src/content/blog/2025-03-new-website-launch.md
@@ -1,6 +1,6 @@
 ---
-title: "TNDの新ホームページがオープンしました！"
-description: "TNDのホームページが新しくなりました。最新の活動情報やプロジェクトの成果をより分かりやすくお届けします。"
+title: "新ホームページがオープンしました！"
+description: "最新の活動情報やプロジェクトの成果をより分かりやすくお届けします。"
 author: "Ryoma"
 role: "主宰"
 authorImage: "https://avatars.githubusercontent.com/u/131366102?v=4"

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -276,16 +276,16 @@ const generateTableOfContents = () => {
         <div class="mt-10 pt-6 border-t border-gray-200">
           <h3 class="text-lg font-semibold mb-4">この記事をシェアする</h3>
           <div class="flex flex-wrap gap-3">
-            <!-- Twitter -->
+            <!-- X (旧Twitter) -->
             <a 
               href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(post.frontmatter.title)}&url=${encodeURIComponent(canonicalURL.toString())}`}
               target="_blank" 
               rel="noopener noreferrer"
-              class="inline-flex items-center justify-center w-10 h-10 bg-[#1DA1F2] text-white rounded-full hover:opacity-90 transition-opacity"
-              aria-label="Twitterでシェア"
+              class="inline-flex items-center justify-center w-10 h-10 bg-black text-white rounded-full hover:opacity-90 transition-opacity"
+              aria-label="Xでシェア"
             >
               <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M8.29 20.251c7.547 0 11.675-6.253 11.675-11.675 0-.178 0-.355-.012-.53A8.348 8.348 0 0022 5.92a8.19 8.19 0 01-2.357.646 4.118 4.118 0 001.804-2.27 8.224 8.224 0 01-2.605.996 4.107 4.107 0 00-6.993 3.743 11.65 11.65 0 01-8.457-4.287 4.106 4.106 0 001.27 5.477A4.072 4.072 0 012.8 9.713v.052a4.105 4.105 0 003.292 4.022 4.095 4.095 0 01-1.853.07 4.108 4.108 0 003.834 2.85A8.233 8.233 0 012 18.407a11.616 11.616 0 006.29 1.84"></path>
+                <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
               </svg>
             </a>
             

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -223,12 +223,12 @@ const generateTableOfContents = () => {
           {post.frontmatter.tags && (
             <div class="flex flex-wrap gap-2 mb-3">
               {post.frontmatter.tags.map((tag: string) => (
-                <a 
-                  href={`/blog/tag/${tag}`} 
-                  class="inline-block px-3 py-1 text-xs font-medium bg-blue-500/80 text-white rounded-full hover:bg-blue-600/80 transition-colors"
+                <span 
+                  class="inline-block px-3 py-1 text-xs font-medium bg-blue-500/80 text-white rounded-full cursor-default select-none"
+                  title={`タグ: ${tag}`}
                 >
                   #{tag}
-                </a>
+                </span>
               ))}
             </div>
           )}
@@ -383,7 +383,21 @@ const generateTableOfContents = () => {
     <!-- 関連記事 -->
     {relatedPosts && relatedPosts.length > 0 && (
       <div class="max-w-5xl mx-auto mt-16">
-        <h2 class="text-2xl font-bold mb-6">関連記事</h2>
+        <div class="flex items-center gap-3 mb-6">
+          <h2 class="text-2xl font-bold">関連記事</h2>
+          {post.frontmatter.tags && post.frontmatter.tags.length > 0 && (
+            <div class="flex flex-wrap gap-2">
+              {post.frontmatter.tags.slice(0, 3).map((tag: string) => (
+                <span class="inline-block px-2 py-1 text-xs font-medium bg-gray-100 text-gray-700 rounded-full">
+                  #{tag}
+                </span>
+              ))}
+              {post.frontmatter.tags.length > 3 && (
+                <span class="text-xs text-gray-500">+{post.frontmatter.tags.length - 3}</span>
+              )}
+            </div>
+          )}
+        </div>
         <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
           {relatedPosts.map((relatedPost) => (
             <a href={relatedPost.url} class="group">
@@ -413,6 +427,19 @@ const generateTableOfContents = () => {
               </article>
             </a>
           ))}
+        </div>
+        
+        <!-- ブログ一覧へのリンク -->
+        <div class="mt-8 text-center">
+          <a 
+            href="/blog" 
+            class="inline-flex items-center px-6 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors"
+          >
+            <span>すべての記事を見る</span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 ml-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+          </a>
         </div>
       </div>
     )}

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -107,10 +107,39 @@ export async function getStaticPaths(): Promise<any[]> {
 const { post, prevPost, nextPost, relatedPosts } = Astro.props;
 const { Content } = post;
 
-// 記事の読了時間を計算（平均読速度: 500文字/分）
-const textContent = post.frontmatter.description || '';
-const wordCount = textContent.length;
-const readingTime = Math.max(1, Math.round(wordCount / 500));
+// 記事の読了時間を計算（平均読速度: 400文字/分）
+// 現在のページのスラッグからファイルパスを特定
+const currentSlug = Astro.params.slug;
+let readingTime = 1; // デフォルト値
+
+try {
+  // 対応するマークダウンファイルを取得
+  const allPosts = await Astro.glob('../../content/blog/*.md');
+  const currentPost = allPosts.find(p => 
+    p.file.split('/').pop()?.replace('.md', '') === currentSlug
+  );
+  
+  if (currentPost && currentPost.rawContent) {
+    // マークダウンの生コンテンツから文字数を計算
+    const textContent = currentPost.rawContent()
+      .replace(/```[\s\S]*?```/g, '') // コードブロックを除去
+      .replace(/`[^`]*`/g, '') // インラインコードを除去
+      .replace(/!\[.*?\]\(.*?\)/g, '') // 画像を除去
+      .replace(/\[.*?\]\(.*?\)/g, '') // リンクを除去
+      .replace(/#{1,6}\s/g, '') // ヘッダーマークダウンを除去
+      .replace(/[*_]{1,2}(.*?)[*_]{1,2}/g, '$1') // 太字・斜体マークダウンを除去
+      .replace(/\n+/g, ' ') // 改行をスペースに変換
+      .trim();
+    
+    const wordCount = textContent.length;
+    readingTime = Math.max(1, Math.round(wordCount / 400)); // 400文字/分で計算
+  }
+} catch (error) {
+  console.warn('読了時間の計算に失敗しました:', error);
+  // フォールバック: タイトル + 説明文から推定
+  const fallbackText = (post.frontmatter.title + ' ' + post.frontmatter.description).length;
+  readingTime = Math.max(1, Math.round(fallbackText / 50)); // より控えめな推定
+}
 
 // 現在のURLを取得（ソーシャルシェア用）
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -126,7 +126,7 @@ function formatDate(dateString: string) {
           すべての記事
         </h2>
 
-        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6 w-full" id="posts-container">
+        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 custom-md:grid-cols-3 gap-6 w-full" id="posts-container">
           {sortedPosts.map((post, index) => {
             const slug = post.file.split('/').pop()?.replace('.md', '');
             const postUrl = `/blog/${slug}`;

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -27,14 +27,24 @@ const sortedPosts = posts.sort((a, b) => {
   return new Date(b.frontmatter.date).getTime() - new Date(a.frontmatter.date).getTime();
 });
 
-// すべてのタグを収集（上位8個まで制限）
-const allTags = [...new Set(
-  sortedPosts
-    .filter(post => post.frontmatter.tags)
-    .flatMap(post => post.frontmatter.tags || [])
-)]
-.slice(0, 8) // 最大8個のタグに制限
-.sort(); // アルファベット順にソート
+// すべてのタグを収集（使用頻度順）
+const tagCounts = new Map();
+sortedPosts
+  .filter(post => post.frontmatter.tags)
+  .flatMap(post => post.frontmatter.tags || [])
+  .forEach(tag => {
+    tagCounts.set(tag, (tagCounts.get(tag) || 0) + 1);
+  });
+
+// 使用頻度順にソートされた全タグ
+const allTagsSorted = Array.from(tagCounts.entries())
+  .sort((a, b) => b[1] - a[1]) // 使用頻度の高い順にソート
+  .map(([tag]) => tag);
+
+// 最初に表示する8個のタグ
+const primaryTags = allTagsSorted.slice(0, 8);
+// 残りのタグ
+const remainingTags = allTagsSorted.slice(8);
 
 // 最新の記事を取得
 const featuredPost = sortedPosts[0];
@@ -62,7 +72,7 @@ function formatDate(dateString: string) {
 
   <main class="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8">
     <!-- Hero Section -->
-    <div class="container flex flex-col md:flex-row items-center gap-10 relative pt-20">
+    <div class="w-full max-w-full md:max-w-full custom-md:max-w-7xl mx-auto flex flex-col md:flex-row items-center gap-10 relative pt-20">
       <Menu client:load />
       <section class="mb-16">
         <h2 class="mb-8 text-gray-900 md:pt-[3rem]" style="color: #000; font-family: 'Rubik Doodle Shadow'; font-size: 38px; font-style: normal; font-weight: 400; line-height: normal;">Blog</h2>
@@ -71,19 +81,36 @@ function formatDate(dateString: string) {
             TNDメンバーが書いた技術記事や活動報告を紹介しています。プログラミングやWeb開発に関する知見を共有しています。
           </p>
         </div>
-        
+
         <!-- タグフィルター -->
-        <div class="mt-8">
+        <div class="mt-8 md:mr-44 custom-md:mr-0">
           <h3 class="text-lg font-semibold mb-4 text-gray-900">タグで絞り込み</h3>
           <div class="flex flex-wrap gap-2">
             <button class="px-3 py-1 bg-blue-500 text-white rounded-full text-sm hover:bg-blue-600 active:bg-blue-700 transition-colors tag-filter active" data-tag="all">
               すべて
             </button>
-            {allTags.map(tag => (
+            {primaryTags.map(tag => (
               <button class={`px-3 py-1 bg-gray-200 text-gray-700 rounded-full text-sm hover:bg-blue-500 hover:text-white active:bg-blue-700 transition-colors tag-filter`} data-tag={tag}>
                 {tag}
               </button>
             ))}
+            {remainingTags.length > 0 && (
+              <>
+                <div id="remaining-tags" class="hidden flex flex-wrap gap-2">
+                  {remainingTags.map(tag => (
+                    <button class={`px-3 py-1 bg-gray-200 text-gray-700 rounded-full text-sm hover:bg-blue-500 hover:text-white active:bg-blue-700 transition-colors tag-filter`} data-tag={tag}>
+                      {tag}
+                    </button>
+                  ))}
+                </div>
+                <button id="show-all-tags" class="px-3 py-1 bg-gray-100 text-gray-600 rounded-full text-sm hover:bg-gray-200 transition-colors border border-gray-300">
+                  +{remainingTags.length}個すべて表示
+                </button>
+                <button id="hide-tags" class="px-3 py-1 bg-gray-100 text-gray-600 rounded-full text-sm hover:bg-gray-200 transition-colors border border-gray-300 hidden">
+                  折りたたむ
+                </button>
+              </>
+            )}
           </div>
         </div>
       </section>
@@ -98,13 +125,13 @@ function formatDate(dateString: string) {
           </span>
           すべての記事
         </h2>
-        
+
         <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6 w-full" id="posts-container">
           {sortedPosts.map((post, index) => {
             const slug = post.file.split('/').pop()?.replace('.md', '');
             const postUrl = `/blog/${slug}`;
             const postTags = post.frontmatter.tags || [];
-            
+
             return (
               <div class="animate-fade-in post-card" style={`animation-delay: ${0.4 + (index % 6) * 0.1}s`} data-tags={JSON.stringify(postTags)}>
                 <NewsCard
@@ -137,34 +164,70 @@ function formatDate(dateString: string) {
   document.addEventListener('DOMContentLoaded', function() {
     const tagFilters = document.querySelectorAll('.tag-filter');
     const postCards = document.querySelectorAll('.post-card');
+    const showAllTagsBtn = document.getElementById('show-all-tags');
+    const hideTagsBtn = document.getElementById('hide-tags');
+    const remainingTags = document.getElementById('remaining-tags');
 
-    tagFilters.forEach(filter => {
-      filter.addEventListener('click', function() {
-        const selectedTag = filter.getAttribute('data-tag');
-        
-        // アクティブなボタンのスタイルを更新
-        tagFilters.forEach(f => {
-          f.classList.remove('active', 'bg-blue-500', 'text-white', 'bg-blue-600', 'bg-blue-700');
-          f.classList.add('bg-gray-200', 'text-gray-700');
-        });
-        
-        filter.classList.add('active', 'bg-blue-500', 'text-white');
-        filter.classList.remove('bg-gray-200', 'text-gray-700');
+    // タグ表示/非表示の切り替え
+    if (showAllTagsBtn) {
+      showAllTagsBtn.addEventListener('click', function() {
+        remainingTags.classList.remove('hidden');
+        remainingTags.classList.add('flex');
+        showAllTagsBtn.classList.add('hidden');
+        hideTagsBtn.classList.remove('hidden');
+      });
+    }
 
-        // 記事をフィルタリング
-        postCards.forEach(card => {
-          const cardTags = JSON.parse(card.getAttribute('data-tags') || '[]');
-          
-          if (selectedTag === 'all' || cardTags.includes(selectedTag)) {
-            card.classList.remove('hidden');
-            card.classList.add('animate-fade-in');
-          } else {
-            card.classList.add('hidden');
-            card.classList.remove('animate-fade-in');
-          }
+    if (hideTagsBtn) {
+      hideTagsBtn.addEventListener('click', function() {
+        remainingTags.classList.add('hidden');
+        remainingTags.classList.remove('flex');
+        hideTagsBtn.classList.add('hidden');
+        showAllTagsBtn.classList.remove('hidden');
+      });
+    }
+
+    // タグフィルタリング機能
+    function updateTagFilters() {
+      const currentTagFilters = document.querySelectorAll('.tag-filter');
+      currentTagFilters.forEach(filter => {
+        filter.addEventListener('click', function() {
+          const selectedTag = filter.getAttribute('data-tag');
+
+          // アクティブなボタンのスタイルを更新
+          currentTagFilters.forEach(f => {
+            f.classList.remove('active', 'bg-blue-500', 'text-white', 'bg-blue-600', 'bg-blue-700');
+            f.classList.add('bg-gray-200', 'text-gray-700');
+          });
+
+          filter.classList.add('active', 'bg-blue-500', 'text-white');
+          filter.classList.remove('bg-gray-200', 'text-gray-700');
+
+          // 記事をフィルタリング
+          postCards.forEach(card => {
+            const cardTags = JSON.parse(card.getAttribute('data-tags') || '[]');
+
+            if (selectedTag === 'all' || cardTags.includes(selectedTag)) {
+              card.classList.remove('hidden');
+              card.classList.add('animate-fade-in');
+            } else {
+              card.classList.add('hidden');
+              card.classList.remove('animate-fade-in');
+            }
+          });
         });
       });
-    });
+    }
+
+    // 初期化
+    updateTagFilters();
+
+    // タグ表示切り替え後にイベントリスナーを再設定
+    if (showAllTagsBtn) {
+      showAllTagsBtn.addEventListener('click', function() {
+        setTimeout(updateTagFilters, 0);
+      });
+    }
   });
 </script>
 
@@ -174,28 +237,28 @@ function formatDate(dateString: string) {
     from { opacity: 0; transform: translateY(10px); }
     to { opacity: 1; transform: translateY(0); }
   }
-  
+
   .animate-fade-in {
     animation: fadeIn 0.6s ease-out forwards;
     opacity: 0;
   }
-  
+
   .animation-delay-100 {
     animation-delay: 0.1s;
   }
-  
+
   .animation-delay-200 {
     animation-delay: 0.2s;
   }
-  
+
   .animation-delay-300 {
     animation-delay: 0.3s;
   }
-  
+
   .animation-delay-400 {
     animation-delay: 0.4s;
   }
-  
+
   /* ホバーエフェクト */
   .line-clamp-2 {
     display: -webkit-box;
@@ -203,14 +266,14 @@ function formatDate(dateString: string) {
     -webkit-box-orient: vertical;
     overflow: hidden;
   }
-  
+
   .line-clamp-3 {
     display: -webkit-box;
     -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;
     overflow: hidden;
   }
-  
+
   /* スムーズスクロール */
   html {
     scroll-behavior: smooth;

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -27,12 +27,14 @@ const sortedPosts = posts.sort((a, b) => {
   return new Date(b.frontmatter.date).getTime() - new Date(a.frontmatter.date).getTime();
 });
 
-// すべてのタグを収集
+// すべてのタグを収集（上位8個まで制限）
 const allTags = [...new Set(
   sortedPosts
     .filter(post => post.frontmatter.tags)
     .flatMap(post => post.frontmatter.tags || [])
-)];
+)]
+.slice(0, 8) // 最大8個のタグに制限
+.sort(); // アルファベット順にソート
 
 // 最新の記事を取得
 const featuredPost = sortedPosts[0];
@@ -59,30 +61,52 @@ function formatDate(dateString: string) {
   </header>
 
   <main class="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8">
+    <!-- Hero Section -->
     <div class="container flex flex-col md:flex-row items-center gap-10 relative pt-20">
       <Menu client:load />
+      <section class="mb-16">
+        <h2 class="mb-8 text-gray-900 md:pt-[3rem]" style="color: #000; font-family: 'Rubik Doodle Shadow'; font-size: 38px; font-style: normal; font-weight: 400; line-height: normal;">Blog</h2>
+        <div class="prose prose-lg max-w-xg text-gray-600 md:max-w-md lg:max-w-xl">
+          <p>
+            TNDメンバーが書いた技術記事や活動報告を紹介しています。プログラミングやWeb開発に関する知見を共有しています。
+          </p>
+        </div>
+        
+        <!-- タグフィルター -->
+        <div class="mt-8">
+          <h3 class="text-lg font-semibold mb-4 text-gray-900">タグで絞り込み</h3>
+          <div class="flex flex-wrap gap-2">
+            <button class="px-3 py-1 bg-blue-500 text-white rounded-full text-sm hover:bg-blue-600 active:bg-blue-700 transition-colors tag-filter active" data-tag="all">
+              すべて
+            </button>
+            {allTags.map(tag => (
+              <button class={`px-3 py-1 bg-gray-200 text-gray-700 rounded-full text-sm hover:bg-blue-500 hover:text-white active:bg-blue-700 transition-colors tag-filter`} data-tag={tag}>
+                {tag}
+              </button>
+            ))}
+          </div>
+        </div>
+      </section>
     </div>
 
-    <!-- ヒーローセクション -->
-    <!-- 省略 -->
-    
     <!-- すべての記事 -->
     <section id="all-posts" class="py-16 animate-fade-in animation-delay-300">
       <div class="container mx-auto px-4">
         <h2 class="text-2xl font-bold mb-8 flex items-center">
-          <span class="inline-block w-8 h-8 bg-blue-500 rounded-full mr-3 flex items-center justify-center text-white">
-            <!-- SVGアイコン -->
+          <span class="w-8 h-8 bg-blue-500 rounded-full mr-3 flex items-center justify-center text-white">
+            📝
           </span>
           すべての記事
         </h2>
         
-        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6 w-full" id="posts-container">
           {sortedPosts.map((post, index) => {
             const slug = post.file.split('/').pop()?.replace('.md', '');
             const postUrl = `/blog/${slug}`;
+            const postTags = post.frontmatter.tags || [];
             
             return (
-              <div class="animate-fade-in" style={`animation-delay: ${0.4 + (index % 6) * 0.1}s`}>
+              <div class="animate-fade-in post-card" style={`animation-delay: ${0.4 + (index % 6) * 0.1}s`} data-tags={JSON.stringify(postTags)}>
                 <NewsCard
                   image={post.frontmatter.image}
                   title={post.frontmatter.title}
@@ -107,6 +131,42 @@ function formatDate(dateString: string) {
       <p class="text-sm text-gray-500">© 2025 TND All Rights Reserved.</p>
     </div>
   </footer>
+
+<script is:inline>
+  // タグフィルタリング機能
+  document.addEventListener('DOMContentLoaded', function() {
+    const tagFilters = document.querySelectorAll('.tag-filter');
+    const postCards = document.querySelectorAll('.post-card');
+
+    tagFilters.forEach(filter => {
+      filter.addEventListener('click', function() {
+        const selectedTag = filter.getAttribute('data-tag');
+        
+        // アクティブなボタンのスタイルを更新
+        tagFilters.forEach(f => {
+          f.classList.remove('active', 'bg-blue-500', 'text-white', 'bg-blue-600', 'bg-blue-700');
+          f.classList.add('bg-gray-200', 'text-gray-700');
+        });
+        
+        filter.classList.add('active', 'bg-blue-500', 'text-white');
+        filter.classList.remove('bg-gray-200', 'text-gray-700');
+
+        // 記事をフィルタリング
+        postCards.forEach(card => {
+          const cardTags = JSON.parse(card.getAttribute('data-tags') || '[]');
+          
+          if (selectedTag === 'all' || cardTags.includes(selectedTag)) {
+            card.classList.remove('hidden');
+            card.classList.add('animate-fade-in');
+          } else {
+            card.classList.add('hidden');
+            card.classList.remove('animate-fade-in');
+          }
+        });
+      });
+    });
+  });
+</script>
 
 <style>
   /* アニメーション */

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -96,7 +96,7 @@ function formatDate(dateString: string) {
             ))}
             {remainingTags.length > 0 && (
               <>
-                <div id="remaining-tags" class="hidden flex flex-wrap gap-2">
+                <div id="remaining-tags" class="hidden flex-wrap gap-2">
                   {remainingTags.map(tag => (
                     <button class={`px-3 py-1 bg-gray-200 text-gray-700 rounded-full text-sm hover:bg-blue-500 hover:text-white active:bg-blue-700 transition-colors tag-filter`} data-tag={tag}>
                       {tag}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -34,26 +34,9 @@ const allTags = [...new Set(
     .flatMap(post => post.frontmatter.tags || [])
 )];
 
-// 最新の記事を取得
-const featuredPost = sortedPosts[0];
-const recentPosts = sortedPosts.slice(1, 4);
-
-// 日付をフォーマット
-function formatDate(dateString: string) {
-  const date = new Date(dateString);
-  if (isNaN(date.getTime())) {
-    console.error(`Invalid date: ${dateString}`);
-    return 'Invalid date';
-  }
-  return new Intl.DateTimeFormat('ja-JP', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric'
-  }).format(date);
-}
-
-// 最新の記事を取得（最大4件）
-const latestPosts = sortedPosts.slice(0, 4);
+// 最新の記事を取得（最大3件）
+const latestPosts = sortedPosts.slice(0, 3);
+const hasMorePosts = sortedPosts.length > 3;
 
 ---
 
@@ -89,13 +72,13 @@ const latestPosts = sortedPosts.slice(0, 4);
       <img src="/mainCharm.svg" alt="mainCharm" class="w-full md:w-auto md:absolute top-[5rem] right-[2rem] max-w-xs md:max-w-md lg:max-w-lg pb-[5rem] opacity-30" />
     </div>
 
-    <div class="container flex flex-col md:flex-row items-center gap-10">
-      <section class="mb-16">
+    <div class="container">
+      <section class="mb-16 w-full">
         <h2 class="mb-8 text-gray-900" style="color: #000; font-family: 'Rubik Doodle Shadow'; font-size: 30px; font-style: normal; font-weight: 400; line-height: normal;">
           NEWS
         </h2>
-        <div class="container flex flex-col md:flex-row gap-5">
-          {sortedPosts.map((post, index) => {
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {latestPosts.map((post, index) => {
             const slug = post.file.split('/').pop()?.replace('.md', '');
             const postUrl = `/blog/${slug}`;
             
@@ -116,6 +99,19 @@ const latestPosts = sortedPosts.slice(0, 4);
             );
           })}
         </div>
+        {hasMorePosts && (
+          <div class="mt-8 text-center">
+            <a 
+              href="/blog" 
+              class="inline-flex items-center px-6 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors font-medium"
+            >
+              もっと見る
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 ml-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+              </svg>
+            </a>
+          </div>
+        )}
       </section>
     </div>
   </main>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -118,26 +118,28 @@ const latestPosts = sortedPosts.slice(0, 4);
         </div>
       </section>
     </div>
-    
-    <!-- SNS LOGOs -->
-    <div class="container items-center md:items-start flex md:flex-col flex-row gap-5 md:absolute bottom-40 left-5">
-      <p class="vertical rotate-180" style="font-family: 'Abel';">-Follow-</p>
-      <a href="https://x.com/TokyorikaND" target="_blank" rel="noopener noreferrer">
-        <img 
-          src="/sns-x.png" 
-          alt="XIcon" 
-          class="w-[1rem] h-[1rem] sm:w-[1.5rem] sm:h-[1.5rem] md:w-[2rem] md:h-[2rem] hover:opacity-80 transition-opacity" 
-        />
-      </a>
-      <a href="https://discord.gg/k3qMBEn3CC" target="_blank" rel="noopener noreferrer">
-        <img 
-          src="/sns-discord.svg" 
-          alt="DiscordIcon" 
-          class="w-[1rem] h-[1rem] sm:w-[1.5rem] sm:h-[1.5rem] md:w-[2rem] md:h-[2rem] hover:opacity-80 transition-opacity" 
-        />
-      </a>
-    </div> 
   </main>
+  
+  <!-- SNS LOGOs - 固定位置（PC画面のみ） -->
+  <div class="hidden md:flex fixed bottom-4 left-4 z-[9999] flex-col items-center gap-3 bg-white/20 backdrop-blur-sm rounded-lg p-4 shadow-xl border border-gray-200/50" style="position: fixed !important;">
+    <p class="text-xs text-gray-700 font-semibold mb-1">Follow</p>
+    <a href="https://x.com/TokyorikaND" target="_blank" rel="noopener noreferrer" class="block">
+      <img 
+        src="/sns-x.png" 
+        alt="XIcon" 
+        class="w-8 h-8 hover:opacity-70 transition-all duration-300 hover:scale-125 block" 
+        style="display: block !important;"
+      />
+    </a>
+    <a href="https://discord.gg/k3qMBEn3CC" target="_blank" rel="noopener noreferrer" class="block">
+      <img 
+        src="/sns-discord.svg" 
+        alt="DiscordIcon" 
+        class="w-8 h-8 hover:opacity-70 transition-all duration-300 hover:scale-125 block" 
+        style="display: block !important;"
+      />
+    </a>
+  </div>
   
   <!-- Footer -->
   <footer class="mt-24 border-t border-gray-200 py-8">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -79,7 +79,7 @@ const latestPosts = sortedPosts.slice(0, 4);
         <h2 class="mb-8 text-gray-900 md:pt-[3rem]" style="color: #000; font-family: 'Rubik Doodle Shadow'; font-size: 38px; font-style: normal; font-weight: 400; line-height: normal;">What's TND</h2>
         <div class="prose prose-lg max-w-xg text-gray-600 md:max-w-md lg:max-w-xl">
           <p>
-            TNDはweb開発をメインに活動する東京理科大学のプログラミングサークルです。2024年に設立され、現在は20名のメンバーが所属しています。
+            TNDはweb開発をメインに活動する東京理科大学のプログラミングサークルです。2024年に設立され、現在は40名のメンバーが所属しています。
           </p>
           <p>
             フロントエンド、バックエンド、デザイン、データサイエンスなど様々な分野の技術を学び、実践しています。

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -34,13 +34,13 @@ const allTags = [...new Set(
     .flatMap(post => post.frontmatter.tags || [])
 )];
 
-// 最新の記事を取得（最大3件）
-const latestPosts = sortedPosts.slice(0, 3);
-const hasMorePosts = sortedPosts.length > 3;
+// 最新の記事を取得（最大4件）
+const latestPosts = sortedPosts.slice(0, 4);
+const hasMorePosts = sortedPosts.length > 4;
 
 ---
 
-<Layout 
+<Layout
   title="TND - 東京理科大学プログラミングサークル | Web開発・データサイエンス"
   description="TNDは東京理科大学野田キャンパスで活動するプログラミングサークルです。Web開発やデータサイエンスに挑戦し、メンバーと共に成長を目指しています。初心者から上級者まで歓迎！"
   keywords={["東京理科大学", "プログラミングサークル", "TND", "Web開発", "データサイエンス", "野田キャンパス", "大学生", "プログラミング", "React", "TypeScript"]}
@@ -56,7 +56,7 @@ const hasMorePosts = sortedPosts.length > 3;
   <main class="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8">
     <!-- Hero Section -->
 
-    <div class="container flex flex-col md:flex-row items-center gap-10 relative pt-20">
+    <div class="w-full max-w-full md:max-w-full custom-md:max-w-7xl mx-auto flex flex-col md:flex-row items-center gap-10 relative pt-20">
       <Menu client:load />
       <section class="mb-16">
         <h2 class="mb-8 text-gray-900 md:pt-[3rem]" style="color: #000; font-family: 'Rubik Doodle Shadow'; font-size: 38px; font-style: normal; font-weight: 400; line-height: normal;">What's TND</h2>
@@ -72,18 +72,23 @@ const hasMorePosts = sortedPosts.length > 3;
       <img src="/mainCharm.svg" alt="mainCharm" class="w-full md:w-auto md:absolute top-[5rem] right-[2rem] max-w-xs md:max-w-md lg:max-w-lg pb-[5rem] opacity-30" />
     </div>
 
-    <div class="container">
+    <div class="w-full max-w-full md:max-w-full custom-md:max-w-7xl mx-auto">
       <section class="mb-16 w-full">
         <h2 class="mb-8 text-gray-900" style="color: #000; font-family: 'Rubik Doodle Shadow'; font-size: 30px; font-style: normal; font-weight: 400; line-height: normal;">
           NEWS
         </h2>
-        <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 custom-md:grid-cols-3 gap-6 max-w-4xl custom-md:max-w-none mx-auto justify-items-center">
           {latestPosts.map((post, index) => {
             const slug = post.file.split('/').pop()?.replace('.md', '');
             const postUrl = `/blog/${slug}`;
-            
+
+            // タブレット時は4つ表示、それ以外は3つ表示
+            const isTabletHidden = index >= 3 ? 'md:block custom-md:hidden' : '';
+            const isMobileDesktopHidden = index >= 3 ? 'hidden custom-md:block' : '';
+            const displayClass = index >= 3 ? `${isTabletHidden} ${isMobileDesktopHidden}` : '';
+
             return (
-              <div class="animate-fade-in" style={`animation-delay: ${0.4 + (index % 6) * 0.1}s`}>
+              <div class={`animate-fade-in ${displayClass}`} style={`animation-delay: ${0.4 + (index % 6) * 0.1}s`}>
                 <NewsCard
                   image={post.frontmatter.image}
                   title={post.frontmatter.title}
@@ -98,11 +103,27 @@ const hasMorePosts = sortedPosts.length > 3;
               </div>
             );
           })}
+
         </div>
-        {hasMorePosts && (
-          <div class="mt-8 text-center">
-            <a 
-              href="/blog" 
+        <!-- もっと見るボタン: スマホ・デスクトップ用（4つ以上で表示） -->
+        {sortedPosts.length > 3 && (
+          <div class="mt-8 text-center md:hidden custom-md:block">
+            <a
+              href="/blog"
+              class="inline-flex items-center px-6 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors font-medium"
+            >
+              もっと見る
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 ml-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+              </svg>
+            </a>
+          </div>
+        )}
+        <!-- もっと見るボタン: タブレット用（5つ以上で表示） -->
+        {sortedPosts.length > 4 && (
+          <div class="mt-8 text-center hidden md:block custom-md:hidden">
+            <a
+              href="/blog"
               class="inline-flex items-center px-6 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors font-medium"
             >
               もっと見る
@@ -115,28 +136,28 @@ const hasMorePosts = sortedPosts.length > 3;
       </section>
     </div>
   </main>
-  
+
   <!-- SNS LOGOs - 固定位置（PC画面のみ） -->
   <div class="hidden md:flex fixed bottom-4 left-4 z-[9999] flex-col items-center gap-3 bg-white/20 backdrop-blur-sm rounded-lg p-4 shadow-xl border border-gray-200/50" style="position: fixed !important;">
     <p class="text-xs text-gray-700 font-semibold mb-1">Follow</p>
     <a href="https://x.com/TokyorikaND" target="_blank" rel="noopener noreferrer" class="block">
-      <img 
-        src="/sns-x.png" 
-        alt="XIcon" 
-        class="w-8 h-8 hover:opacity-70 transition-all duration-300 hover:scale-125 block" 
+      <img
+        src="/sns-x.png"
+        alt="XIcon"
+        class="w-8 h-8 hover:opacity-70 transition-all duration-300 hover:scale-125 block"
         style="display: block !important;"
       />
     </a>
     <a href="https://discord.gg/k3qMBEn3CC" target="_blank" rel="noopener noreferrer" class="block">
-      <img 
-        src="/sns-discord.svg" 
-        alt="DiscordIcon" 
-        class="w-8 h-8 hover:opacity-70 transition-all duration-300 hover:scale-125 block" 
+      <img
+        src="/sns-discord.svg"
+        alt="DiscordIcon"
+        class="w-8 h-8 hover:opacity-70 transition-all duration-300 hover:scale-125 block"
         style="display: block !important;"
       />
     </a>
   </div>
-  
+
   <!-- Footer -->
   <footer class="mt-24 border-t border-gray-200 py-8">
     <div class="mx-auto max-w-7xl px-4 text-center sm:px-6 lg:px-8">


### PR DESCRIPTION
1. ニュースカードのレイアウトを調整しました
- タイトルは1行まで
- 説明は2行まで
- 超過した場合は最後に...となる

2. topのメンバーを20人から40人に変更しました

3. ブログ記事の最初に読み終わるまでの時間が表示されていましたが、全て「1分」になってるバグを修正しました
- マークダウンを読んで400字を1分として計算しています。

4. ブログトップにヒーローを追加し、タグ検索を可能にしました

5. TwitterのアイコンをXにしました。topページのSNSを右下固定・スクロール追従にしました

6. topページに表示されるニュースカードは3つまでで、それ以上は「もっと見る」ボタンを実装しました
- 現在3件しか記事がないので表示されていない。(ローカルで表示確認済み)