### PR TITLE
fix(about): チームタブ切り替えボタンにおける、click属性を削除しました。

### DIFF
--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -106,13 +106,13 @@ import TwoLine from '../../components/TwoLine.astro';
         </h2>
         <div class="flex justify-center mb-8" x-data="{ activeTab: 'web' }">
           <div class="inline-flex rounded-lg border border-gray-200 bg-white p-1">
-            <button class="px-4 py-2 text-sm font-medium rounded-md transition-colors duration-300 web-tab" onclick="activateTab('web')">
+            <button class="px-4 py-2 text-sm font-medium rounded-md transition-colors duration-300 web-tab">
               ウェブ開発
             </button>
-            <button class="px-4 py-2 text-sm font-medium rounded-md transition-colors duration-300 design-tab" onclick="activateTab('design')">
+            <button class="px-4 py-2 text-sm font-medium rounded-md transition-colors duration-300 design-tab">
               デザイン
             </button>
-            <button class="px-4 py-2 text-sm font-medium rounded-md transition-colors duration-300 data-tab" onclick="activateTab('data')">
+            <button class="px-4 py-2 text-sm font-medium rounded-md transition-colors duration-300 data-tab">
               データサイエンス
             </button>
           </div>


### PR DESCRIPTION
チームInfoタブを切り替える際、エラーメッセージが出ていた問題を修正しました。
修正前では以下のような動作だったところを
・各々タブ要素に、onClick属性によってタブ切り替えイベントを付与
修正後は以下のような動作に切り替えていることを確認してください。
・各々タブ要素では該当イベントを付与していない。