### PR TITLE
ci(deploy): 👷 Webhook取りこぼし対策の定期リビルドを追加

### DIFF
--- a/.github/workflows/astro-deploy.yml
+++ b/.github/workflows/astro-deploy.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+  schedule:
+    # Webhook 取りこぼし時の保険。6時間ごとに再ビルドして microCMS の最新状態へ追従する（UTC）
+    - cron: "0 */6 * * *"
   repository_dispatch: # microCMS の Webhook からのトリガー（記事の公開・更新時）
     types: [microcms-publish]
 


### PR DESCRIPTION
## 背景
microCMS で記事を削除/編集しても、Webhook が届かず自動リビルドが走らないケースがあった（手動 rebuild で対応した経緯）。

本番は GitHub Pages（静的）＝ビルド時点のスナップショットなので、反映には再ビルドが必要。通常は microCMS Webhook → `repository_dispatch` で再ビルドされるが、**Webhook を取りこぼすと本番が古いまま**になる。

## 変更
`schedule`（6時間ごとの cron）をデプロイワークフローに追加。Webhook を取りこぼしても、**定期的に再ビルド＆デプロイして microCMS の最新状態へ自動追従**する安全網。

```yaml
schedule:
  - cron: "0 */6 * * *"  # UTC・6時間ごと
```

- スケジュール実行は `github.ref == refs/heads/main` を満たすため build→deploy が走る（pr-comment ジョブは pull_request 限定で発火しない）
- 間隔は運用に応じて調整可

## 補足（本質的な直しは microCMS 側）
この cron はあくまで保険。即時反映の本筋は Webhook なので、**microCMS の「Webhook 配信ログ」で削除時に送信されているか／トークン期限・権限（Contents: RW）** を別途確認するのが根本対応。